### PR TITLE
fix: 画面チラつき問題を修正、PierとWaterを削除

### DIFF
--- a/Hope/src/animation/HopeAnimation.ts
+++ b/Hope/src/animation/HopeAnimation.ts
@@ -18,6 +18,7 @@ export class HopeAnimation {
 	private readonly assetLoader: AssetLoader
 	private readonly renderer: THREE.WebGLRenderer
 	private readonly bgImage: HTMLElement | null
+	private lastHopeFactor = 0 // For throttling updates
 
 	constructor(
 		params: SceneParams,
@@ -88,6 +89,12 @@ export class HopeAnimation {
 
 	private updateScene(): void {
 		const hopeFactor = this.params.hopeFactor
+
+		// Skip update if change is too small (reduces flickering)
+		if (Math.abs(hopeFactor - this.lastHopeFactor) < 0.01) {
+			return
+		}
+		this.lastHopeFactor = hopeFactor
 
 		// Rain fading
 		const rainOpacity = THREE.MathUtils.lerp(1, 0, hopeFactor)

--- a/Hope/src/effects/GodRays.ts
+++ b/Hope/src/effects/GodRays.ts
@@ -102,9 +102,9 @@ export class GodRays {
 					// Combine fades
 					float alpha = rayOpacity * centerFade;
 
-					// Animated shimmer effect (slower and subtler)
-					float shimmer = sin(vUv.y * 10.0 - uTime * 0.5) * 0.05 + 0.95;
-					alpha *= shimmer;
+					// Shimmer effect disabled - causes flickering
+					// float shimmer = sin(vUv.y * 10.0 - uTime * 0.5) * 0.05 + 0.95;
+					// alpha *= shimmer;
 
 					// Apply hope factor - rays only visible when hope increases
 					alpha *= uHopeFactor * 0.6;
@@ -120,7 +120,7 @@ export class GodRays {
 			`,
 			transparent: true,
 			blending: THREE.AdditiveBlending,
-			side: THREE.DoubleSide,
+			side: THREE.FrontSide, // Changed from DoubleSide to reduce flickering
 			depthWrite: false,
 		})
 	}
@@ -129,8 +129,8 @@ export class GodRays {
 		this.material.uniforms.uTime.value = time
 		this.material.uniforms.uHopeFactor.value = hopeFactor
 
-		// Subtle rotation animation
-		this.mesh.rotation.y = Math.sin(time * 0.1) * 0.05
+		// Rotation animation disabled - causes flickering
+		// this.mesh.rotation.y = Math.sin(time * 0.1) * 0.05
 	}
 
 	public getObject(): THREE.Mesh {

--- a/Hope/src/scene/SceneManager.ts
+++ b/Hope/src/scene/SceneManager.ts
@@ -167,13 +167,9 @@ export class SceneManager {
 		this.lightParticles.update(time, this.params.hopeFactor)
 		this.godRays.update(time, this.params.hopeFactor)
 
-		// Camera breathing effect (subtler with hope)
-		const cameraShake = THREE.MathUtils.lerp(
-			0.15,
-			0.03,
-			this.params.hopeFactor
-		)
-		this.camera.position.y += Math.sin(time * 0.3) * cameraShake * 0.1
+		// Camera breathing effect removed - caused flickering
+		// const cameraShake = THREE.MathUtils.lerp(0.15, 0.03, this.params.hopeFactor)
+		// this.camera.position.y += Math.sin(time * 0.3) * cameraShake * 0.1
 
 		this.postProcessing.render()
 	}

--- a/Hope/src/scene/objects/Fog.ts
+++ b/Hope/src/scene/objects/Fog.ts
@@ -4,7 +4,7 @@ export class Fog {
 	private readonly particles: THREE.Points
 	private readonly geometry: THREE.BufferGeometry
 	private readonly material: THREE.ShaderMaterial
-	private readonly particleCount = 100 // Reduced from 500 to prevent large visible squares
+	private readonly particleCount = 50 // Minimal fog particles
 	private readonly velocities: Float32Array
 
 	constructor() {
@@ -23,18 +23,18 @@ export class Fog {
 		for (let i = 0; i < this.particleCount; i++) {
 			const i3 = i * 3
 
-			// Position - spread around the scene
-			positions[i3] = (Math.random() - 0.5) * 80
-			positions[i3 + 1] = Math.random() * 8 - 2
-			positions[i3 + 2] = (Math.random() - 0.5) * 60 - 10
+			// Position - spread far from camera to avoid large squares
+			positions[i3] = (Math.random() - 0.5) * 100
+			positions[i3 + 1] = Math.random() * 10 - 5
+			positions[i3 + 2] = -30 - Math.random() * 50 // Place far behind camera
 
 			// Velocity - slow drifting motion
 			this.velocities[i3] = (Math.random() - 0.5) * 0.02
 			this.velocities[i3 + 1] = (Math.random() - 0.5) * 0.01
 			this.velocities[i3 + 2] = (Math.random() - 0.5) * 0.02
 
-			// Scale variation - much smaller to avoid large squares
-			scales[i] = Math.random() * 0.8 + 0.3
+			// Scale variation - very small
+			scales[i] = Math.random() * 0.3 + 0.1
 
 			// Random offset for animation
 			randoms[i] = Math.random()
@@ -55,7 +55,7 @@ export class Fog {
 			uniforms: {
 				uTime: { value: 0 },
 				uHopeFactor: { value: 0 },
-				uSize: { value: 30 }, // Reduced from 100
+				uSize: { value: 15 }, // Very small fog particles
 				uPixelRatio: { value: Math.min(window.devicePixelRatio, 2) },
 			},
 			vertexShader: `
@@ -89,9 +89,9 @@ export class Fog {
 					gl_PointSize *= (1.0 / -viewPosition.z);
 					
 					// Alpha based on distance and hope factor
-					// Fog is more visible in storm, less in hope (reduced opacity)
-					float stormAlpha = 0.15;
-					float hopeAlpha = 0.05;
+					// Fog is more visible in storm, less in hope (very subtle)
+					float stormAlpha = 0.08;
+					float hopeAlpha = 0.02;
 					vAlpha = mix(stormAlpha, hopeAlpha, uHopeFactor);
 					vRandom = aRandom;
 				}
@@ -116,8 +116,8 @@ export class Fog {
 					vec3 hopeColor = vec3(0.8, 0.75, 0.7);
 					vec3 color = mix(stormColor, hopeColor, uHopeFactor);
 					
-					// Subtle pulsing (slower and less intense)
-					alpha *= 0.9 + sin(uTime * 0.3 + vRandom * 10.0) * 0.1;
+					// No pulsing animation - constant alpha
+					// alpha *= 0.9 + sin(uTime * 0.3 + vRandom * 10.0) * 0.1;
 					
 					gl_FragColor = vec4(color, alpha);
 				}

--- a/Hope/src/scene/objects/LightParticles.ts
+++ b/Hope/src/scene/objects/LightParticles.ts
@@ -4,7 +4,7 @@ export class LightParticles {
 	private readonly particles: THREE.Points
 	private readonly geometry: THREE.BufferGeometry
 	private readonly material: THREE.ShaderMaterial
-	private readonly particleCount = 200
+	private readonly particleCount = 80 // Reduced from 200
 	private readonly basePositions: Float32Array
 
 	constructor() {
@@ -37,8 +37,8 @@ export class LightParticles {
 			this.basePositions[i3 + 1] = positions[i3 + 1]
 			this.basePositions[i3 + 2] = positions[i3 + 2]
 
-			// Scale - small glowing particles
-			scales[i] = Math.random() * 0.5 + 0.2
+			// Scale - very small glowing particles
+			scales[i] = Math.random() * 0.3 + 0.1
 
 			// Random offset for animation
 			randoms[i] = Math.random() * Math.PI * 2
@@ -59,7 +59,7 @@ export class LightParticles {
 			uniforms: {
 				uTime: { value: 0 },
 				uHopeFactor: { value: 0 },
-				uSize: { value: 60 },
+				uSize: { value: 25 }, // Reduced from 60
 				uPixelRatio: { value: Math.min(window.devicePixelRatio, 2) },
 				uColor: { value: new THREE.Color(0xf5d98a) },
 			},
@@ -96,8 +96,8 @@ export class LightParticles {
 					gl_PointSize = uSize * aScale * uPixelRatio;
 					gl_PointSize *= (1.0 / -viewPosition.z);
 					
-					// Only visible when hope factor is high (smoother animation)
-					vAlpha = uHopeFactor * (0.8 + sin(uTime * 0.5 + aRandom * 8.0) * 0.2);
+					// Only visible when hope factor is high (no pulsing)
+					vAlpha = uHopeFactor * 0.8;
 					vRandom = aRandom;
 				}
 			`,

--- a/Hope/src/scene/objects/Rain.ts
+++ b/Hope/src/scene/objects/Rain.ts
@@ -4,7 +4,7 @@ export class Rain {
 	private readonly points: THREE.Points
 	private readonly geometry: THREE.BufferGeometry
 	private readonly material: THREE.PointsMaterial
-	private readonly rainCount = 10000
+	private readonly rainCount = 3000 // Reduced from 10000
 
 	constructor() {
 		this.geometry = this.createGeometry()
@@ -30,9 +30,9 @@ export class Rain {
 	private createMaterial(): THREE.PointsMaterial {
 		return new THREE.PointsMaterial({
 			color: 0xaaaaaa,
-			size: 0.1,
+			size: 0.05, // Smaller rain drops
 			transparent: true,
-			opacity: 1,
+			opacity: 0.7,
 		})
 	}
 

--- a/Hope/src/styles.css
+++ b/Hope/src/styles.css
@@ -117,8 +117,11 @@ body {
 	object-position: center;
 	transform: translate(-50%, -50%);
 	filter: brightness(0.4) saturate(0.8);
-	transition: filter 2s ease, transform 0.1s ease;
-	will-change: transform, filter;
+	/* Removed conflicting CSS transitions - GSAP handles animations */
+	will-change: transform;
+	/* Use GPU acceleration for smoother rendering */
+	backface-visibility: hidden;
+	-webkit-backface-visibility: hidden;
 }
 
 .background-overlay {
@@ -430,7 +433,7 @@ body {
 	gap: var(--space-xl);
 	background: var(--color-bg-dark);
 	z-index: var(--z-modal);
-	transition: opacity 1s ease;
+	transition: opacity 0.5s ease; /* Faster fade out */
 }
 
 .loading-spinner {
@@ -488,7 +491,7 @@ body {
 	text-align: center;
 	opacity: 0;
 	transform: translateY(50px);
-	transition: opacity 0.8s ease, transform 0.8s ease;
+	transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .story-content.visible {
@@ -540,7 +543,7 @@ body {
 	text-align: center;
 	opacity: 0;
 	transform: translateY(30px);
-	transition: opacity 0.8s ease, transform 0.8s ease;
+	transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .experience-content.visible {


### PR DESCRIPTION
- GodRaysのshimmerアニメーションと回転アニメーションを無効化（チラつきの根本原因）
- GodRaysのDoubleSide→FrontSideに変更
- Fog/Rain/LightParticlesのパーティクル数・サイズを最適化
- カメラシェイクを削除
- スクロールハンドラーにスロットリングを追加
- CSSトランジションを高速化（0.8s→0.3s）
- HopeAnimationにスロットリングを追加
- PierとWaterの3Dオブジェクトを完全削除