### PR TITLE
refactor: type名を表示コンテンツに合わせてリネーム

### DIFF
--- a/Hope/src/components/App.tsx
+++ b/Hope/src/components/App.tsx
@@ -62,11 +62,11 @@ export function App() {
 			<BackgroundLayer />
 			<Navigation />
 			<Hero />
-			<StorySection type="storm" />
-			<StorySection type="change" />
 			<StorySection type="hope" />
+			<StorySection type="life" />
+			<StorySection type="possibility" />
 			<ExperienceSection />
-			<StorySection type="about" />
+			<StorySection type="light" />
 			<VideoOverlay />
 			<ThreeCanvas />
 		</div>

--- a/Hope/src/components/Navigation.tsx
+++ b/Hope/src/components/Navigation.tsx
@@ -12,7 +12,7 @@ export function Navigation() {
 			</a>
 			<ul className="nav-links">
 				<li>
-					<a href="#story" className="nav-link">
+					<a href="#hope" className="nav-link">
 						Hope
 					</a>
 				</li>
@@ -22,7 +22,7 @@ export function Navigation() {
 					</a>
 				</li>
 				<li>
-					<a href="#about" className="nav-link">
+					<a href="#light" className="nav-link">
 						Light
 					</a>
 				</li>

--- a/Hope/src/components/StorySection.tsx
+++ b/Hope/src/components/StorySection.tsx
@@ -2,11 +2,11 @@ import { useState } from "react"
 import { ImageModal } from "./ImageModal"
 
 interface StorySectionProps {
-	type: "storm" | "change" | "hope" | "about"
+	type: "hope" | "life" | "possibility" | "light"
 }
 
 const storyContent = {
-	storm: {
+	hope: {
 		number: "01",
 		title: "Hope",
 		description: (
@@ -17,7 +17,7 @@ const storyContent = {
 		),
 		image: "/images/hope-pillar.webp",
 	},
-	change: {
+	life: {
 		number: "02",
 		title: "Life",
 		description: (
@@ -30,7 +30,7 @@ const storyContent = {
 		),
 		image: "/images/live-learn-forever.webp",
 	},
-	hope: {
+	possibility: {
 		number: "03",
 		title: "Possibility",
 		description: (
@@ -41,7 +41,7 @@ const storyContent = {
 		),
 		image: "/images/never-too-late.webp",
 	},
-	about: {
+	light: {
 		number: "∞",
 		title: "Light",
 		description: (
@@ -57,13 +57,13 @@ const storyContent = {
 /**
  * Renders a story section (number, title, and description) for the given section type.
  *
- * @param type - The section variant to render: "storm", "change", "hope", or "about"
+ * @param type - The section variant to render: "hope", "life", "possibility", or "light"
  * @returns A <section> element containing the configured number, title, and description for the specified type
  */
 export function StorySection({ type }: StorySectionProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false)
 	const content = storyContent[type]
-	const sectionId = type === "storm" ? "story" : type === "about" ? "about" : undefined
+	const sectionId = type === "hope" ? "hope" : type === "light" ? "light" : undefined
 
 	const handleImageClick = () => {
 		setIsModalOpen(true)


### PR DESCRIPTION
- StorySection type: storm→hope, change→life, hope→possibility, about→light
- Navigation: セクションリンクを#story→#hope, #about→#lightに変更
- App.tsx: StorySection呼び出しのtype propsを更新
- JSDocコメントを新しいtype名で更新