### PR TITLE
Refactor tests to use shared cleanup and mock helpers

### DIFF
--- a/Hope/src/components/__tests__/VideoOverlay.test.tsx
+++ b/Hope/src/components/__tests__/VideoOverlay.test.tsx
@@ -1,30 +1,21 @@
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { useAppStore } from "../../store"
+import { cleanupFullscreenAPI, commonCleanup } from "../../test/helpers/cleanup"
 import { VideoOverlay } from "../VideoOverlay"
 
-// happy-domがiframe srcをfetchしないようモック
-vi.mock("../../utils/youtube", () => ({
-	YOUTUBE_VIDEO_ID: "test-video-id",
-}))
-
-// barrelインポート経由でScrollTriggerが読み込まれ、_rafBugFixが
-// 同期RAFモックと無限再帰を起こすのを防止
-vi.mock("gsap/ScrollTrigger", () => ({
-	ScrollTrigger: {
-		create: vi.fn(),
-		getAll: vi.fn(() => []),
-		refresh: vi.fn(),
-	},
-}))
-
-vi.mock("gsap", () => ({
-	gsap: {
-		timeline: vi.fn(),
-		to: vi.fn(),
-		registerPlugin: vi.fn(),
-	},
-}))
+vi.mock("../../utils/youtube", async () => {
+	const { mockYoutubeUtils } = await import("../../test/mocks/video")
+	return mockYoutubeUtils()
+})
+vi.mock("gsap/ScrollTrigger", async () => {
+	const { mockScrollTrigger } = await import("../../test/mocks/video")
+	return mockScrollTrigger()
+})
+vi.mock("gsap", async () => {
+	const { mockGSAP } = await import("../../test/mocks/video")
+	return mockGSAP()
+})
 
 describe("VideoOverlay", () => {
 	beforeEach(() => {
@@ -41,24 +32,8 @@ describe("VideoOverlay", () => {
 	})
 
 	afterEach(async () => {
-		vi.useRealTimers()
-		vi.restoreAllMocks()
-		// Prevent fullscreenElement / exitFullscreen leaking between tests
-		Object.defineProperty(document, "fullscreenElement", {
-			value: null,
-			configurable: true,
-		})
-		Object.defineProperty(document, "exitFullscreen", {
-			value: undefined,
-			configurable: true,
-			writable: true,
-		})
-		// happy-domのpending非同期タスク（iframe navigation等）をクリーンアップ
-		// biome-ignore lint/suspicious/noExplicitAny: happy-dom internal API
-		const happyDOM = (window as any).happyDOM
-		if (happyDOM?.abort) {
-			await happyDOM.abort()
-		}
+		await commonCleanup()
+		cleanupFullscreenAPI()
 	})
 
 	it("should not render when isVideoOverlayVisible is false", () => {

--- a/Hope/src/components/__tests__/VideoThumbnail.test.tsx
+++ b/Hope/src/components/__tests__/VideoThumbnail.test.tsx
@@ -1,30 +1,21 @@
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { useAppStore } from "../../store"
+import { commonCleanup } from "../../test/helpers/cleanup"
 import { VideoThumbnail } from "../VideoThumbnail"
 
-// happy-domがiframe srcをfetchしないようモック
-vi.mock("../../utils/youtube", () => ({
-	YOUTUBE_VIDEO_ID: "test-video-id",
-}))
-
-// barrelインポート経由でScrollTriggerが読み込まれ、_rafBugFixが
-// 同期RAFモックと無限再帰を起こすのを防止
-vi.mock("gsap/ScrollTrigger", () => ({
-	ScrollTrigger: {
-		create: vi.fn(),
-		getAll: vi.fn(() => []),
-		refresh: vi.fn(),
-	},
-}))
-
-vi.mock("gsap", () => ({
-	gsap: {
-		timeline: vi.fn(),
-		to: vi.fn(),
-		registerPlugin: vi.fn(),
-	},
-}))
+vi.mock("../../utils/youtube", async () => {
+	const { mockYoutubeUtils } = await import("../../test/mocks/video")
+	return mockYoutubeUtils()
+})
+vi.mock("gsap/ScrollTrigger", async () => {
+	const { mockScrollTrigger } = await import("../../test/mocks/video")
+	return mockScrollTrigger()
+})
+vi.mock("gsap", async () => {
+	const { mockGSAP } = await import("../../test/mocks/video")
+	return mockGSAP()
+})
 
 describe("VideoThumbnail", () => {
 	beforeEach(() => {
@@ -43,14 +34,7 @@ describe("VideoThumbnail", () => {
 	})
 
 	afterEach(async () => {
-		vi.useRealTimers()
-		vi.restoreAllMocks()
-		// happy-domのpending非同期タスク（iframe navigation等）をクリーンアップ
-		// biome-ignore lint/suspicious/noExplicitAny: happy-dom internal API
-		const happyDOM = (window as any).happyDOM
-		if (happyDOM?.abort) {
-			await happyDOM.abort()
-		}
+		await commonCleanup()
 	})
 
 	it("should render and apply visible class on mount", () => {

--- a/Hope/src/test/helpers/cleanup.ts
+++ b/Hope/src/test/helpers/cleanup.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest"
+
+/**
+ * 共通テストクリーンアップ処理
+ * - タイマーをリアルタイマーに戻す
+ * - 全モックをリストア
+ * - happy-domのpending非同期タスクをクリーンアップ
+ */
+export const commonCleanup = async () => {
+	vi.useRealTimers()
+	vi.restoreAllMocks()
+
+	// happy-domのpending非同期タスク（iframe navigation等）をクリーンアップ
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom internal API
+	const happyDOM = (window as any).happyDOM
+	if (happyDOM?.abort) {
+		await happyDOM.abort()
+	}
+}
+
+/**
+ * Fullscreen API クリーンアップ
+ * VideoOverlay テスト用: fullscreenElement と exitFullscreen のリセット
+ */
+export const cleanupFullscreenAPI = () => {
+	// Prevent fullscreenElement / exitFullscreen leaking between tests
+	Object.defineProperty(document, "fullscreenElement", {
+		value: null,
+		configurable: true,
+	})
+	Object.defineProperty(document, "exitFullscreen", {
+		value: undefined,
+		configurable: true,
+		writable: true,
+	})
+}

--- a/Hope/src/test/mocks/video.ts
+++ b/Hope/src/test/mocks/video.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest"
+
+/**
+ * YouTube ユーティリティモック
+ * happy-domがiframe srcをfetchしないようモック
+ */
+export const mockYoutubeUtils = () => ({
+	YOUTUBE_VIDEO_ID: "test-video-id",
+})
+
+/**
+ * GSAP ScrollTrigger モック
+ * barrelインポート経由でScrollTriggerが読み込まれ、_rafBugFixが
+ * 同期RAFモックと無限再帰を起こすのを防止
+ */
+export const mockScrollTrigger = () => ({
+	ScrollTrigger: {
+		create: vi.fn(),
+		getAll: vi.fn(() => []),
+		refresh: vi.fn(),
+	},
+})
+
+/**
+ * GSAP コアライブラリモック
+ */
+export const mockGSAP = () => ({
+	gsap: {
+		timeline: vi.fn(),
+		to: vi.fn(),
+		registerPlugin: vi.fn(),
+	},
+})


### PR DESCRIPTION
- Extracted common cleanup logic to helpers/cleanup.ts
- Extracted shared mocks to mocks/video.ts
- Updated VideoOverlay.test.tsx and VideoThumbnail.test.tsx to use these helpers
